### PR TITLE
Add Custom Init-Containers to funnel helm chart

### DIFF
--- a/charts/funnel/README.md
+++ b/charts/funnel/README.md
@@ -112,16 +112,16 @@ A toolkit for distributed task execution ⚙️
 | Worker.MaxParallelTransfers | int | `10` |  |
 | Worker.PollingRate | string | `"5s"` |  |
 | Worker.WorkDir | string | `"./funnel-work-dir"` |  |
-| image.initContainer.command[0] | string | `"cp"` |  |
-| image.initContainer.command[1] | string | `"/app/build/plugins/authorizer"` |  |
-| image.initContainer.command[2] | string | `"/opt/funnel/plugin-binaries/auth-plugin"` |  |
-| image.initContainer.image | string | `"quay.io/ohsu-comp-bio/funnel-plugins"` |  |
-| image.initContainer.pullPolicy | string | `"Always"` |  |
-| image.initContainer.tag | string | `"pr-1"` |  |
-| image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"quay.io/ohsu-comp-bio/funnel"` |  |
-| initVolumeMounts[0].mountPath | string | `"/opt/funnel/plugin-binaries"` |  |
-| initVolumeMounts[0].name | string | `"plugin-volume"` |  |
+| image.repository | string | `"quay.io/ohsu-comp-bio/funnel"` | Funnel container image repository |
+| image.pullPolicy | string | `"Always"` | Funnel container image pull policy |
+| image.initContainers | list | `[]` | List of initContainers to run before Funnel starts. Each item can define `name`, `image`, `tag`, `pullPolicy`, `command`, `args`, `env`, and `volumeMounts`. |
+| image.initContainers[0].name | string | `"plugins"` | Name of the initContainer |
+| image.initContainers[0].image | string | `"quay.io/ohsu-comp-bio/funnel-plugins"` | InitContainer image repository |
+| image.initContainers[0].tag | string | `"pr-1"` | InitContainer image tag |
+| image.initContainers[0].pullPolicy | string | `"Always"` | InitContainer image pull policy |
+| image.initContainers[0].command | list | `["cp", "/app/build/plugins/authorizer", "/opt/funnel/plugin-binaries/auth-plugin"]` | Command to execute in the initContainer |
+| image.initContainers[0].env | list | `[]` | Optional environment variables for the initContainer |
+| image.initContainers[0].volumeMounts | list | `[{"name": "plugin-volume", "mountPath": "/opt/funnel/plugin-binaries"}]` | Volume mounts for the initContainer |
 | labels.app | string | `"funnel"` |  |
 | mongodb.app | string | `"funnel-mongodb"` |  |
 | mongodb.architecture | string | `"standalone"` |  |

--- a/charts/funnel/templates/server-deployment.yaml
+++ b/charts/funnel/templates/server-deployment.yaml
@@ -44,8 +44,12 @@ spec:
           {{- end }}
           {{- if .volumeMounts }}
           volumeMounts:
-          {{- toYaml .volumeMounts | nindent 6 }}
+          {{- toYaml .volumeMounts | nindent 10 }}
           {{- end }}
+          {{- if .env }}
++         env:
++          {{- toYaml .env | nindent 10 }}
++          {{- end }}
       {{- end }}
       {{- end }}
       containers:

--- a/charts/funnel/templates/server-deployment.yaml
+++ b/charts/funnel/templates/server-deployment.yaml
@@ -24,17 +24,30 @@ spec:
         checksum/values: {{ .Values | quote | sha256sum }}
     spec:
       serviceAccountName: funnel-sa-{{ .Release.Namespace }}
-      {{ if .Values.Plugins }}
+      {{- if .Values.image.initContainers }}
       initContainers:
-        - name: plugins
-          image: {{ .Values.image.initContainer.image }}:{{ .Values.image.initContainer.tag }}
-          imagePullPolicy: Always
-          volumeMounts:
-          {{- toYaml .Values.initVolumeMounts | nindent 10 }}
-          command: {{- range .Values.image.initContainer.command }}
-            - {{ . }}
+      {{- range .Values.image.initContainers }}
+        - name: {{ .name | default "initcontainer" }}
+          image: "{{ .image }}:{{ .tag }}"
+          imagePullPolicy: {{ .pullPolicy | default "IfNotPresent" }}
+          {{- if .command }}
+          command:
+          {{- range .command }}
+            - {{ . | quote }}
           {{- end }}
-      {{ end }}
+          {{- end }}
+          {{- if .args }}
+          args:
+          {{- range .args }}
+            - {{ . | quote }}
+          {{- end }}
+          {{- end }}
+          {{- if .volumeMounts }}
+          volumeMounts:
+          {{- toYaml .volumeMounts | nindent 6 }}
+          {{- end }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: funnel
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/funnel/values.yaml
+++ b/charts/funnel/values.yaml
@@ -5,14 +5,15 @@ image:
   repository: quay.io/ohsu-comp-bio/funnel
   pullPolicy: Always
   # Plugin Init Container
-  initContainer:
-    image: quay.io/ohsu-comp-bio/funnel-plugins
-    tag: pr-1
-    pullPolicy: Always
-    command:
-      - cp
-      - /app/build/plugins/authorizer
-      - /opt/funnel/plugin-binaries/auth-plugin
+  initContainers:
+    - name: plugins
+      image: quay.io/ohsu-comp-bio/funnel-plugins
+      tag: pr-1
+      pullPolicy: Always
+      command:
+        - cp
+        - /app/build/plugins/authorizer
+        - /opt/funnel/plugin-binaries/auth-plugin
 
 labels:
   app: funnel

--- a/charts/funnel/values.yaml
+++ b/charts/funnel/values.yaml
@@ -14,6 +14,9 @@ image:
         - cp
         - /app/build/plugins/authorizer
         - /opt/funnel/plugin-binaries/auth-plugin
+      volumeMounts:
+        - name: plugin-volume
+          mountPath: /opt/funnel/plugin-binaries
 
 labels:
   app: funnel
@@ -487,9 +490,3 @@ volumeMounts:
 
   - name: plugin-volume
     mountPath: /opt/funnel/plugin-binaries
-
-# Overrides the default init container VolumesMounts configured in the server deployment.
-# If custom init container volumesMounts are specified, they will fully replace the default values.
-initVolumeMounts:
-- name: plugin-volume
-  mountPath: /opt/funnel/plugin-binaries

--- a/charts/funnel/values.yaml
+++ b/charts/funnel/values.yaml
@@ -4,8 +4,8 @@ replicaCount: 1
 image:
   repository: quay.io/ohsu-comp-bio/funnel
   pullPolicy: Always
-  # Plugin Init Container
   initContainers:
+    # Plugin Init Container
     - name: plugins
       image: quay.io/ohsu-comp-bio/funnel-plugins
       tag: pr-1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR enhances the Funnel Helm chart by enabling users to define custom init-containers and their environment variables, volume mounts, and full configuration through the values.yaml. It replaces the previous hardcoded approach to add init-containers only based on `.Values.plugin` with a dynamic solution.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Flexibility: Users can now tailor the init phase of Funnel deployments to their needs—such as running multiple pre-start tasks, handling plugin setup, configuring secrets, or any other such orchestration.
* Configurability: Full customization via values.yaml allows changes without altering chart templates.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran -->
<!--- Describe how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I have updated the documentation accordingly (link here).
- [x] I have tested that this feature locally.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Reviewer has tested this feature locally
