### PR TITLE
Making changes to funnel helm chart to fix issues in 0.1.66 release

### DIFF
--- a/charts/funnel/files/rolebinding.yaml
+++ b/charts/funnel/files/rolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     taskId: {{`{{.TaskId}}`}}
 subjects:
 - kind: ServiceAccount
-  name: funnel-worker-sa-{{`{{.Namespace}}`}}-{{`{{.TaskId}}`}}
+  name: {{`{{.ServiceAccount}}`}}
   namespace: {{`{{.Namespace}}`}}
 roleRef:
   kind: Role

--- a/charts/funnel/files/rolebinding.yaml
+++ b/charts/funnel/files/rolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     taskId: {{`{{.TaskId}}`}}
 subjects:
 - kind: ServiceAccount
-  name: {{`{{.ServiceAccount}}`}}
+  name: {{`{{.ServiceAccountName}}`}}
   namespace: {{`{{.Namespace}}`}}
 roleRef:
   kind: Role

--- a/charts/funnel/files/serviceaccount.yaml
+++ b/charts/funnel/files/serviceaccount.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   # Note: Only creating ServiceAccount here, not required to create new Role or RoleBinding
   # TODO: Set defaults for case no custom values are being supplied from the TES Task Tags
-  name: {{`{{.Name}}`}}
+  name: {{`{{.ServiceAccountName}}`}}
   namespace: {{`{{.Namespace}}`}}
   labels:
     app: funnel

--- a/charts/funnel/files/worker-job.yaml
+++ b/charts/funnel/files/worker-job.yaml
@@ -94,7 +94,7 @@ spec:
       volumes:
       - name: config-volume
         configMap:
-          name: funnel-worker-config-{{.TaskId}}
+          name: funnel-worker-config-{{`{{.TaskId}}`}}
       {{`
       {{- if .NeedsPVC }}
       - name: funnel-storage-{{.TaskId}}

--- a/charts/funnel/files/worker-pv.yaml
+++ b/charts/funnel/files/worker-pv.yaml
@@ -17,8 +17,10 @@ spec:
     - allow-overwrite
     - region={{`{{.Region}}`}}
     - file-mode=0755
+    {{`{{- if .KmsKeyID}}`}}
     - sse aws:kms
     - sse-kms-key-id={{`{{.KmsKeyID}}`}}
+    {{`{{- end}}`}}
   csi:
     driver: s3.csi.aws.com
     volumeHandle: s3-csi-{{`{{.TaskId}}`}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR addresses issues that were identified after funnel-0.1.66 release. 

## Description
<!--- Describe your changes in detail -->
This PR addresses multiple issues introduced in `funnel-0.1.66`  preventing Funnel from correctly creating and running worker and executor jobs when using dynamically generated service accounts and Helm-templated values. The changes ensure service account selection, PVC naming, and job creation work reliably and consistently.

1. Fix service account reference in `serviceaccount.yaml` 
2. Fix missing `TaskId` substitution under volumes in `worker-job.yaml`
3. Ensure role-binding is done appropriately to the right ServiceAccount in `rolebinding.yaml`
4. Ensure `worker-pv` does not fail if KMS Key ID is `null`


Note: 

- Logic to ensure creation of serviceaccount being idempotent is required on the Funnel side.  
- Funnel must provide ServiceAccountName for the template [here](https://github.com/ohsu-comp-bio/funnel/blob/85a5832c895f6270729176d307852171921272c1/compute/kubernetes/resources/roleBinding.go#L31-L34C4)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran -->
<!--- Describe how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I have updated the documentation accordingly (link here).
- [ ] I have tested that this feature locally.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Reviewer has tested this feature locally
