### PR TITLE
feat: Add initial Postgres support to Funnel chart

### DIFF
--- a/charts/funnel/Chart.yaml
+++ b/charts/funnel/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.71
+version: 0.1.72
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 2025-12-14
+appVersion: 2025-12-17
 
 dependencies:
   - name: mongodb

--- a/charts/funnel/Chart.yaml
+++ b/charts/funnel/Chart.yaml
@@ -23,7 +23,7 @@ version: 0.1.72
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 2025-12-17
+appVersion: 2025-12-19
 
 dependencies:
   - name: mongodb

--- a/charts/funnel/files/server-config.yaml
+++ b/charts/funnel/files/server-config.yaml
@@ -149,6 +149,16 @@ MongoDB:
   Username: {{ .Values.MongoDB.Username }}
   Password: {{ .Values.MongoDB.Password }}
 
+Postgres:
+  Host: {{ .Values.Postgres.Host }}
+  Database: {{ .Values.Postgres.Database }}
+  User: {{ .Values.Postgres.User }}
+  Password: {{ .Values.Postgres.Password }}
+  AdminUser: {{ .Values.Postgres.AdminUser }}
+  AdminPassword: {{ .Values.Postgres.AdminPassword }}
+  Timeout:
+    duration: {{ .Values.Postgres.Timeout.duration }}
+
 Kafka:
   Servers:
   {{- if .Values.Kafka.Servers }}

--- a/charts/funnel/values.yaml
+++ b/charts/funnel/values.yaml
@@ -21,6 +21,23 @@ image:
 labels:
   app: funnel
 
+# Funnel Server (Task Database)
+mongodb:
+  enabled: false
+  app: funnel-mongodb
+  commonLabels:
+    app: funnel-mongodb
+  image:
+    registry: public.ecr.aws
+  architecture: standalone
+  auth:
+    enabled: true
+    rootUser: example
+    rootPassword: example
+  persistence:
+    enabled: false
+    size: 1Gi
+
 rbac:
   create: true
 
@@ -235,15 +252,18 @@ MongoDB:
     duration: 300s
   # Username and Password inform the credentials for the initial authentication
   # done on the database defined by the Database field.
-  Username: ""
-  Password: ""
+  Username: example
+  Password: example
 
 Postgres:
-  Addrs:
-    - "localhost"
-  Database: "funnel"
-  Username: ""
-  Password: ""
+  Host: localhost
+  Database: funnel
+  User: funnel
+  Password: example
+  AdminUser: postgres
+  AdminPassword: example
+  Timeout:
+    duration: 300s
 
 Kafka:
   Topic: funnel

--- a/charts/funnel/values.yaml
+++ b/charts/funnel/values.yaml
@@ -21,22 +21,6 @@ image:
 labels:
   app: funnel
 
-# Funnel Server (Task Database)
-mongodb:
-  app: funnel-mongodb
-  commonLabels:
-    app: funnel-mongodb
-  image:
-    registry: public.ecr.aws
-  architecture: standalone
-  auth:
-    enabled: true
-    rootUser: example
-    rootPassword: example
-  persistence:
-    enabled: false
-    size: 1Gi
-
 rbac:
   create: true
 
@@ -81,7 +65,7 @@ storage:
 
 # The name of the active server database backend
 # Available backends: boltdb, badger, datastore, dynamodb, elastic, mongodb
-Database: mongodb
+Database: postgres
 
 # The name of the active compute backend
 # Available backends: local, htcondor, slurm, pbs, gridengine, manual, aws-batch, kubernetes
@@ -90,7 +74,7 @@ Compute: kubernetes
 # The name of the active event writer backend(s).
 # Available backends: log, boltdb, badger, datastore, dynamodb, elastic, mongodb, kafka
 EventWriters:
-  - mongodb
+  - postgres
   - log
 
 Logger:
@@ -251,8 +235,15 @@ MongoDB:
     duration: 300s
   # Username and Password inform the credentials for the initial authentication
   # done on the database defined by the Database field.
-  Username: example
-  Password: example
+  Username: ""
+  Password: ""
+
+Postgres:
+  Addrs:
+    - "localhost"
+  Database: "funnel"
+  Username: ""
+  Password: ""
 
 Kafka:
   Topic: funnel


### PR DESCRIPTION
# Overview

This PR adds the new [Postgres support](https://github.com/ohsu-comp-bio/funnel/pull/1264) from Funnel!

> [!TIP]
>
> [feature/postgres → develop #1264](https://github.com/ohsu-comp-bio/funnel/pull/1264)

# Previous Behavior

No Postgres support, requires separate Mongo or ElasticSearch deployment.

# New Behavior

## 1. Update Config

`values.yaml`
```yaml
Database: postgres

Postgres:
  Host: localhost
  Database: funnel
  User: funnel
  Password: example
```

## 2. Update Helm Repo

```sh
➜ helm repo update ohsu
Update Complete. ⎈Happy Helming!⎈

➜ helm search repo ohsu
NAME                    CHART VERSION   APP VERSION     DESCRIPTION
ohsu/funnel             0.1.72          2025-12-17      A toolkit for distributed task execution ⚙️
```

## 3. Deploy

```sh
➜ helm upgrade --install funnel ohsu/funnel -f values.yaml
```

## 4. Expected State

- [x] Funnel Server starts up successfully and connects to the specified Postgres instance
- [x] No Mongo instance is created as part of the deployment
- [x] Able to run the following task operations successfully:
  - [x] `LIST` tasks
  - [x] `CREATE` tasks
  - [x] `GET` tasks,
  - [x] `CANCEL` tasks

# Next Steps

- [ ] Should Funnel bring up a standalone Postgres instance by default (similar to Mongo) if not provided with a `Postgres` config? This would be similar in scope to the embedded/BoltDB for local storage...