### PR TITLE
Customize K8s replica count for funnel-server

### DIFF
--- a/charts/funnel/templates/server-deployment.yaml
+++ b/charts/funnel/templates/server-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "funnel.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.Kubernetes.ReplicaCount }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/charts/funnel/values.yaml
+++ b/charts/funnel/values.yaml
@@ -1,6 +1,3 @@
-# Kubernetes-specifc Settings
-replicaCount: 1
-
 image:
   repository: quay.io/ohsu-comp-bio/funnel
   pullPolicy: Always

--- a/charts/funnel/values.yaml
+++ b/charts/funnel/values.yaml
@@ -424,6 +424,8 @@ Kubernetes:
   # ReconcileRate is how often the compute backend compares states in Funnel's backend
   # to those reported by the backend
   ReconcileRate: 10s
+  # Number of funnel-server replicas to run.
+  ReplicaCount: 1
   # Kubernetes Namespace to spawn jobs within
   Namespace: ""
   # Kubernetes Namespace to spawn jobs within


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Current funnel-server replica count is hardcoded to 1 in the deployment helm chart.  This PR attempts to dynamically update it from values.yaml. 
* Moved `{{ .Values.replicaCount }}` to `{{ .Values.Kubernetes.ReplicaCount }}` where it is more relevant, with a matching Camelcase name
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran -->
<!--- Describe how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I have updated the documentation accordingly (link here).
- [x] I have tested that this feature locally.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Reviewer has tested this feature locally
