### PR TITLE
Add Priority class name to worker and executor pods

### DIFF
--- a/charts/funnel/files/executor-job.yaml
+++ b/charts/funnel/files/executor-job.yaml
@@ -12,6 +12,22 @@ spec:
   completions: {{ .Values.completions }}
   template:
     metadata:
+
+    # If priorityClassName is set for the Executor, use that. 
+    # Otherwise, if it's set for the Worker, use that. 
+    # This allows users to set a default priority class for all jobs by setting it for the Worker,
+    # but also override it for the Executor if needed.
+    {{- $pc := ""}}
+    {{- if .Values.Kubernetes.Executor.PriorityClassName }}
+      {{- $pc = .Values.Kubernetes.Executor.PriorityClassName }}
+    {{- else if .Values.Kubernetes.Worker.PriorityClassName }}
+      {{- $pc = .Values.Kubernetes.Worker.PriorityClassName }}
+    {{- end }}
+
+    {{- if $pc }}
+      priorityClassName: {{ $pc }}
+    {{- end }}
+
       # Annotations
     {{- with .Values.Kubernetes.Executor.Annotations }}
       annotations:

--- a/charts/funnel/files/worker-job.yaml
+++ b/charts/funnel/files/worker-job.yaml
@@ -24,6 +24,10 @@ spec:
         app: funnel-worker
         task-id: {{`{{.TaskId}}`}}
     spec:
+    
+    {{ if .Values.Kubernetes.Worker.PriorityClassName }}
+      priorityClassName: {{ .Values.Kubernetes.Worker.PriorityClassName }}
+    {{ end }}
       # NodeSelectors
       # https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/#create-a-pod-that-gets-scheduled-to-your-chosen-node
       {{`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add `PriorityClassName` for worker and executor jobs if provided on `.Values.kubernetes.Worker.PriorityClassName` and `.Values.kubernetes.Executor.PriorityClassName`. 
- If `Executor.PriorityClassName` is not provided, fallback to  `Worker.PriorityClassName`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran -->
<!--- Describe how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I have updated the documentation accordingly (link here).
- [x] I have tested that this feature locally.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Reviewer has tested this feature locally
