### PR TITLE
Consistent and flexible worker and executor configuration

### DIFF
--- a/charts/funnel/files/executor-job.yaml
+++ b/charts/funnel/files/executor-job.yaml
@@ -8,8 +8,8 @@ metadata:
     app: funnel-executor
     job-name: {{`{{.TaskId}}-{{.JobId}}`}}
 spec:
-  backoffLimit: {{ .Values.backoffLimit}}
-  completions: {{ .Values.completions }}
+  backoffLimit: {{ .Values.Kubernetes.Executor.backoffLimit}}
+  completions: {{ .Values.Kubernetes.Executor.completions }}
   template:
     metadata:
 
@@ -74,7 +74,7 @@ spec:
       {{- end }}
       `}}
 
-      restartPolicy: {{ .Values.restartPolicy.executor }}
+      restartPolicy: {{ .Values.Kubernetes.Executor.restartPolicy }}
       serviceAccountName: {{`{{.ServiceAccountName}}`}}
       containers:
       - name: funnel-worker-{{`{{.TaskId}}`}}

--- a/charts/funnel/files/worker-job.yaml
+++ b/charts/funnel/files/worker-job.yaml
@@ -16,13 +16,20 @@ metadata:
     {{- end }}
     `}}
 spec:
-  backoffLimit: {{ .Values.backoffLimit}}
-  completions: {{ .Values.completions }}
+  backoffLimit: {{ .Values.Kubernetes.Worker.backoffLimit}}
+  completions: {{ .Values.Kubernetes.Worker.completions }}
   template:
     metadata:
       labels:
         app: funnel-worker
         task-id: {{`{{.TaskId}}`}}
+
+    # Annotations
+    {{- with .Values.Kubernetes.Worker.Annotations }}
+      annotations:
+      {{ toYaml . | indent 2 }}
+    {{- end }}
+
     spec:
     
     {{ if .Values.Kubernetes.Worker.PriorityClassName }}
@@ -67,7 +74,7 @@ spec:
       `}}
 
       serviceAccountName: {{`{{.ServiceAccountName}}`}}
-      restartPolicy: {{ .Values.restartPolicy.worker }}
+      restartPolicy: {{ .Values.Kubernetes.Worker.restartPolicy }}
       containers:
       - name: funnel-worker-{{`{{.TaskId}}`}}
         image: {{`{{.Image}}`}}

--- a/charts/funnel/values.yaml
+++ b/charts/funnel/values.yaml
@@ -422,7 +422,7 @@ Kubernetes:
     # Note: This value is not currently saved in the Funnel Server config and only visible by describing the Executor Pod itself (e.g. `kubectl describe pod <pod-name>`).
     # Ref: executor-job.yaml#spec.template.metadata.annotations
     Annotations: {}
-    PriorityClassName:
+    PriorityClassName: ""
     restartPolicy: OnFailure
     # Setting `backoffLimit` to 0 means no retries
     # Setting `completions` to 1 means the job will be marked as complete after a single successful execution.
@@ -432,7 +432,7 @@ Kubernetes:
     completions: 1
   Worker:
     Annotations: {}
-    PriorityClassName:
+    PriorityClassName: ""
     restartPolicy: Never
     backoffLimit: 0
     completions: 1

--- a/charts/funnel/values.yaml
+++ b/charts/funnel/values.yaml
@@ -55,17 +55,6 @@ mongodb:
 rbac:
   create: true
 
-# Backoff/Completions for Worker + Executor Jobs
-# Setting `backoffLimit` to 0 means no retries 
-# Setting `completions` to 1 means the job will be marked as complete after a single successful execution.
-# Funnel should not be restarting jobs (by default) so that clients can choose their preferred retry behavior
-# TODO: Should Funnel offer a built-in retry mechanism that users can configure on a per-task basis?
-backoffLimit: 0
-completions: 1
-restartPolicy:
-  executor: OnFailure
-  worker: Never
-
 # Resource Requests/Limits for Worker Jobs
 # Executor resource defaults/limits are in Kubernetes.Resources
 resources:
@@ -429,11 +418,25 @@ AWSBatch:
 
 # Kubernetes describes the configuration for the Kubernetes compute backend.
 Kubernetes:
-  # Note: This value is not currently saved in the Funnel Server config and only visible by describing the Executor Pod itself (e.g. `kubectl describe pod <pod-name>`).
-  # Ref: executor-job.yaml#spec.template.metadata.annotations
   Executor:
+    # Note: This value is not currently saved in the Funnel Server config and only visible by describing the Executor Pod itself (e.g. `kubectl describe pod <pod-name>`).
+    # Ref: executor-job.yaml#spec.template.metadata.annotations
     Annotations: {}
-  Worker: {}
+    PriorityClassName:
+    restartPolicy: OnFailure
+    # Setting `backoffLimit` to 0 means no retries
+    # Setting `completions` to 1 means the job will be marked as complete after a single successful execution.
+    # Funnel should not be restarting jobs (by default) so that clients can choose their preferred retry behavior
+    # TODO: Should Funnel offer a built-in retry mechanism that users can configure on a per-task basis?
+    backoffLimit: 0
+    completions: 1
+  Worker:
+    Annotations: {}
+    PriorityClassName:
+    restartPolicy: Never
+    backoffLimit: 0
+    completions: 1
+
   # Turn off task state reconciler. When enabled, Funnel communicates with Kubernetes
   # to find tasks that are stuck in a queued state or errored and
   # updates the task state accordingly.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Ability to configure the worker's and the executor's `backoffLimit` and `completions` configurations separately
- Move the `backoffLimit`, `completions`, `restartPolicy.executor` and `restartPolicy.worker` configurations to the `Kubernetes.Executor` and `Kubernetes.Worker` sections to be consistent with the existing `Annotations` and `PriorityClassName` configurations

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran -->
<!--- Describe how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I have updated the documentation accordingly (link here).
- [ ] I have tested that this feature locally.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Reviewer has tested this feature locally
