### PR TITLE
feat: Add initial CronJob as external reconciler for resource cleanup

### DIFF
--- a/charts/funnel/templates/_helpers.tpl
+++ b/charts/funnel/templates/_helpers.tpl
@@ -65,3 +65,55 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Parse a Go duration string (e.g. "10s", "90s", "5m", "1h") into whole seconds.
+Only the s/m/h suffixes are supported; an unsuffixed value is treated as seconds.
+Returns 0 when the input is empty or unparseable.
+*/}}
+{{- define "funnel.durationSeconds" -}}
+{{- $d := . | toString | trim -}}
+{{- $seconds := 0 -}}
+{{- if hasSuffix "h" $d -}}
+{{- $seconds = mul (trimSuffix "h" $d | int) 3600 -}}
+{{- else if hasSuffix "m" $d -}}
+{{- $seconds = mul (trimSuffix "m" $d | int) 60 -}}
+{{- else if hasSuffix "s" $d -}}
+{{- $seconds = trimSuffix "s" $d | int -}}
+{{- else if $d -}}
+{{- $seconds = $d | int -}}
+{{- end -}}
+{{- $seconds -}}
+{{- end }}
+
+{{/*
+Derive the cleanup CronJob schedule.
+
+If .Values.cleanup.schedule is set explicitly, it wins. Otherwise the schedule is
+derived from .Values.Kubernetes.ReconcileRate so the CronJob shares a single source
+of truth with the server's reconcile cadence.
+
+A Kubernetes CronJob has minute granularity, so ReconcileRate is rounded up to whole
+minutes (with a floor of 1). When the interval is under an hour the minute field uses
+a step expression; intervals of an hour or more step the hour field instead.
+.Values.cleanup.scheduleOffsetMinutes offsets the start minute so deployments in
+different namespaces do not all fire simultaneously.
+*/}}
+{{- define "funnel.cleanupSchedule" -}}
+{{- if .Values.cleanup.schedule -}}
+{{- .Values.cleanup.schedule -}}
+{{- else -}}
+{{- $seconds := include "funnel.durationSeconds" .Values.Kubernetes.ReconcileRate | int -}}
+{{- $minutes := div (add $seconds 59) 60 -}}
+{{- if lt $minutes 1 }}{{- $minutes = 1 -}}{{- end -}}
+{{- $offset := .Values.cleanup.scheduleOffsetMinutes | default 0 | int -}}
+{{- if and (le $minutes 59) (eq (mod 60 $minutes) 0) -}}
+{{- printf "%d-59/%d * * * *" $offset $minutes -}}
+{{- else if le $minutes 59 -}}
+{{- printf "%d/%d * * * *" $offset $minutes -}}
+{{- else -}}
+{{- $hours := div (add $minutes 59) 60 -}}
+{{- printf "%d */%d * * *" $offset $hours -}}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/charts/funnel/templates/cronjob.yaml
+++ b/charts/funnel/templates/cronjob.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.cleanup.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: funnel-cleanup-{{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "funnel.labels" . | nindent 4 }}
+spec:
+  # Offset the minute so deployments in different namespaces don't all fire simultaneously.
+  schedule: {{ printf "%d %s" (.Values.cleanup.scheduleOffsetMinutes | int) (trimPrefix (printf "%d " (.Values.cleanup.scheduleOffsetMinutes | int)) .Values.cleanup.schedule) | default .Values.cleanup.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "funnel.labels" . | nindent 12 }}
+        spec:
+          serviceAccountName: funnel-sa-{{ .Release.Namespace }}
+          restartPolicy: OnFailure
+          containers:
+            - name: funnel-cleanup
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: Always
+              command:
+                - funnel
+                - kubernetes
+                - cleanup
+                - --config
+                - /etc/config/funnel-server.yaml
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: "128Mi"
+                limits:
+                  cpu: "500m"
+                  memory: "256Mi"
+              volumeMounts:
+              {{- toYaml .Values.volumeMounts | nindent 14 }}
+          volumes:
+          {{- toYaml .Values.volumes | nindent 10 }}
+{{- end }}

--- a/charts/funnel/templates/cronjob.yaml
+++ b/charts/funnel/templates/cronjob.yaml
@@ -7,8 +7,10 @@ metadata:
   labels:
     {{- include "funnel.labels" . | nindent 4 }}
 spec:
-  # Offset the minute so deployments in different namespaces don't all fire simultaneously.
-  schedule: {{ printf "%d %s" (.Values.cleanup.scheduleOffsetMinutes | int) (trimPrefix (printf "%d " (.Values.cleanup.scheduleOffsetMinutes | int)) .Values.cleanup.schedule) | default .Values.cleanup.schedule | quote }}
+  # Schedule is derived from Kubernetes.ReconcileRate unless cleanup.schedule is set
+  # explicitly. scheduleOffsetMinutes offsets the start minute so deployments in
+  # different namespaces don't all fire simultaneously. See funnel.cleanupSchedule.
+  schedule: {{ include "funnel.cleanupSchedule" . | quote }}
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/charts/funnel/values.yaml
+++ b/charts/funnel/values.yaml
@@ -478,6 +478,24 @@ Kubernetes:
       RamGb: 4096Mi
       DiskGb: 4096Mi
 
+# cleanup configures the external-reconciler CronJob, which runs
+# `funnel kubernetes cleanup` to delete orphaned Funnel-managed Kubernetes
+# resources (PVs, ServiceAccounts, executor jobs) whose task is gone or terminal.
+cleanup:
+  # Enable the cleanup CronJob. When enabled, prefer disabling the in-server
+  # reconciler (Kubernetes.DisableReconciler) so the two don't run concurrently.
+  enabled: false
+
+  # How often the CronJob runs. Leave empty to derive the schedule from
+  # Kubernetes.ReconcileRate (rounded up to whole minutes, since a CronJob cannot
+  # run more often than once per minute). Set a standard 5-field cron expression
+  # to override, e.g. "*/15 * * * *" for every 15 minutes.
+  schedule: ""
+
+  # Offsets the start minute so cleanup jobs in different namespaces don't all fire
+  # at the same instant. Must be 0-59.
+  scheduleOffsetMinutes: 0
+
 #-------------------------------------------------------------------------------
 # Storage
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
# Overview 🌀

This PR adds an initial cronjob to act as an  for resource cleanup in K8s (i.e. "external reconciler")

It runs an example command (`funnel kubernetes cleanup`) that is designed to call the update "modular reconciler" implemented in [uc-cdis:funnel:chore/reconcile_modular](https://github.com/uc-cdis/funnel/tree/chore/reconcile_modular)

> [!TIP]
>
> https://github.com/calypr/funnel/compare/develop...uc-cdis:funnel:chore/reconcile_modular

## Current Behavior ⚠️

K8s resource cleanup is run in the resource-intensive (and complicated!) functions directly in Funnel:

- [`(kubernetes.Backend).reconcile`](https://github.com/calypr/funnel/blob/2026-05-06.2/compute/kubernetes/backend.go#L369-L386)
- [`(kubernetes.Backend).CleanOrphanedResources`](https://github.com/calypr/funnel/blob/2026-05-06.2/compute/kubernetes/backend.go#L598-L604)

## New Behavior ✔️ 

Resources are cleaned in a single, user-configurable Helm template.

> [!CAUTION]
>
> TODO: Add examples of defaults + configuration options, for example:
> - Which resources to clean (default: all)
> - Time period between cleans (default: 300s?)

## Backwards Compatibilty 🔄

> [!CAUTION]
>
> TODO: Does this new behavior affect existing workflows/setups?
> - Likely yes, as the reconciler was first added to Funnel in Commit [c108da6](https://github.com/calypr/funnel/commit/c108da644ee6705562702a323bd0787cba475074#diff-6b8bdaf0017913b075ada768862a9fcce4ec277e19e8fb5692e2dc2e01347e0aR171-R188) (Feb 20, 2020)
> - Steps to make ensure compatible with previous builds (e.g. feature flag)?