### PR TITLE
chore: Normalize `taskId` labels

### DIFF
--- a/charts/funnel/README.md
+++ b/charts/funnel/README.md
@@ -52,7 +52,7 @@ A toolkit for distributed task execution ⚙️
 | GridEngine.TemplateFile | string | `""` |  |
 | HTCondor.DisableReconciler | bool | `true` |  |
 | HTCondor.ReconcileRate | string | `"10s"` |  |
-| HTCondor.Template | string | `"universe = vanilla\ngetenv = True\nexecutable = {{.Executable}}\narguments = worker run --config {{.Config}} --task-id {{.TaskId}}\nlog = {{.WorkDir}}/condor-event-log\nerror = {{.WorkDir}}/funnel-stderr\noutput = {{.WorkDir}}/funnel-stdout\nshould_transfer_files = YES\nwhen_to_transfer_output = ON_EXIT_OR_EVICT\n{{if ne .Cpus 0 -}}\n{{printf \"request_cpus = %d\" .Cpus}}\n{{- end}}\n{{if ne .RamGb 0.0 -}}\n{{printf \"request_memory = %.0f GB\" .RamGb}}\n{{- end}}\n{{if ne .DiskGb 0.0 -}}\n{{printf \"request_disk = %.0f GB\" .DiskGb}}\n{{- end}}\n\nqueue\n"` |  |
+| HTCondor.Template | string | `"universe = vanilla\ngetenv = True\nexecutable = {{.Executable}}\narguments = worker run --config {{.Config}} --taskId {{.TaskId}}\nlog = {{.WorkDir}}/condor-event-log\nerror = {{.WorkDir}}/funnel-stderr\noutput = {{.WorkDir}}/funnel-stdout\nshould_transfer_files = YES\nwhen_to_transfer_output = ON_EXIT_OR_EVICT\n{{if ne .Cpus 0 -}}\n{{printf \"request_cpus = %d\" .Cpus}}\n{{- end}}\n{{if ne .RamGb 0.0 -}}\n{{printf \"request_memory = %.0f GB\" .RamGb}}\n{{- end}}\n{{if ne .DiskGb 0.0 -}}\n{{printf \"request_disk = %.0f GB\" .DiskGb}}\n{{- end}}\n\nqueue\n"` |  |
 | HTCondor.TemplateFile | string | `""` |  |
 | HTTPStorage.Timeout | string | `"30s"` |  |
 | Kafka.Topic | string | `"funnel"` |  |

--- a/charts/funnel/files/worker-job.yaml
+++ b/charts/funnel/files/worker-job.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{`{{.JobsNamespace}}`}}
   labels:
     app: funnel-worker
-    task-id: {{`{{.TaskId}}`}}
+    taskId: {{`{{.TaskId}}`}}
     # Custom Labels support
     {{`
     {{- range $key, $value := .ExtraLabels }}
@@ -22,7 +22,7 @@ spec:
     metadata:
       labels:
         app: funnel-worker
-        task-id: {{`{{.TaskId}}`}}
+        taskId: {{`{{.TaskId}}`}}
 
     # Annotations
     {{- with .Values.Kubernetes.Worker.Annotations }}

--- a/charts/funnel/values.yaml
+++ b/charts/funnel/values.yaml
@@ -308,7 +308,7 @@ HTCondor:
     universe = vanilla
     getenv = True
     executable = {{.Executable}}
-    arguments = worker run --config {{.Config}} --task-id {{.TaskId}}
+    arguments = worker run --config {{.Config}} --taskId {{.TaskId}}
     log = {{.WorkDir}}/condor-event-log
     error = {{.WorkDir}}/funnel-stderr
     output = {{.WorkDir}}/funnel-stdout


### PR DESCRIPTION
# Overview

This PR normalizes all `taskId` labels used in Worker Job spec (`worker-job.yaml`)!

## Current Behavior ⚠️

Mixed use of `task-id` and `taskId` labels in templates.

## New Behavior ✔️

All labels normalized to `taskId` to match existing Funnel values (e.g. in [`job.go`](https://github.com/calypr/funnel/blob/2026-05-12/compute/kubernetes/resources/job.go#L75)).