### PR TITLE
release/funnel: v0.1.99.-rc.36 (2026-05-22)

### DIFF
--- a/charts/funnel/Chart.yaml
+++ b/charts/funnel/Chart.yaml
@@ -23,7 +23,7 @@ version: "0.1.99-rc.36"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2026-05-12"
+appVersion: "2026-05-22"
 
 dependencies:
   - name: postgresql

--- a/charts/funnel/Chart.yaml
+++ b/charts/funnel/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.1.99-rc.35"
+version: "0.1.99-rc.36"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
# Overview 🌀

This PR releases Funnel 2026-05-22 with the following updates:

* Add Gen3-Funnel integration tests by @paulineribeyre in https://github.com/calypr/funnel/pull/1404
* Remove MinIO v6 dep in favor of MinIO v7 by @lbeckman314 in https://github.com/calypr/funnel/pull/1415
* fix Docker tags format for branches by @lbeckman314 in https://github.com/calypr/funnel/pull/1417

**Full Changelog**: https://github.com/calypr/funnel/compare/2026-05-12...2026-05-22