### PR TITLE
fix: Update Helm Docs to run on PR's

### DIFF
--- a/.github/workflows/helm-docs.yml
+++ b/.github/workflows/helm-docs.yml
@@ -1,0 +1,32 @@
+name: Update Helm Docs
+
+on:
+  pull_request:
+    paths:
+      - charts/**/Chart.yaml
+      - charts/**/values.yaml
+      - charts/**/templates/**
+
+permissions:
+  contents: write
+
+jobs:
+  helm-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run helm-docs
+        uses: losisin/helm-docs-github-action@v1
+        with:
+          git-push: true
+          git-commit-message: "chore: update chart documentation [skip ci]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,19 +40,11 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      
-      - run: git pull
 
       - name: Add Bitnami Repo
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo update
-
-      - name: Run helm-docs
-        uses: losisin/helm-docs-github-action@v1
-        with:
-          git-push: true
-          git-commit-message: "chore: update chart documentation [skip ci]"
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0


### PR DESCRIPTION
# Overview

This PR allows developers to keep the Branch Protection [ruleset](https://github.com/calypr/helm-charts/settings/rules) enabled (no direct pushed to `main`) as the Helm Docs action will commit/update the docs on the PR branch itself (e.g. `fix/enable-ruleset`) rather than `main`.

