### PR TITLE
Release Helm Chart `v0.1.99-rc.37` (`2026-05-27`)

### DIFF
--- a/.github/workflows/helm-docs.yml
+++ b/.github/workflows/helm-docs.yml
@@ -8,7 +8,7 @@ on:
       - charts/**/templates/**
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   helm-docs:
@@ -20,13 +20,14 @@ jobs:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
       - name: Run helm-docs
         uses: losisin/helm-docs-github-action@v1
         with:
-          git-push: true
-          git-commit-message: "chore: update chart documentation [skip ci]"
+          git-push: false
+
+      - name: Check for uncommitted changes
+        run: |
+          if ! git diff --exit-code; then
+            echo "helm-docs output is out of date. Run helm-docs locally and commit the changes."
+            exit 1
+          fi

--- a/charts/funnel/Chart.yaml
+++ b/charts/funnel/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.1.99-rc.36"
+version: "0.1.99-rc.37"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2026-05-22"
+appVersion: "2026-05-27"
 
 dependencies:
   - name: postgresql

--- a/charts/funnel/README.md
+++ b/charts/funnel/README.md
@@ -1,6 +1,6 @@
 # funnel
 
-![Version: 0.1.99-rc.36](https://img.shields.io/badge/Version-0.1.99--rc.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026-05-22](https://img.shields.io/badge/AppVersion-2026--05--22-informational?style=flat-square)
+![Version: 0.1.99-rc.37](https://img.shields.io/badge/Version-0.1.99--rc.37-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026-05-27](https://img.shields.io/badge/AppVersion-2026--05--27-informational?style=flat-square)
 
 A toolkit for distributed task execution ⚙️
 

--- a/charts/funnel/files/role.yaml
+++ b/charts/funnel/files/role.yaml
@@ -33,7 +33,7 @@ rules:
   resources: ["persistentvolumeclaims"]
   verbs: ["create", "get", "list", "watch", "delete"]
 
-# Events (for job status reporting)
+# Events (for job status reporting and surfacing pod warning events to users)
 - apiGroups: [""]
   resources: ["events"]
-  verbs: ["create", "patch"]
+  verbs: ["create", "patch", "get", "list", "watch"]

--- a/charts/funnel/files/worker-pv-posix.yaml
+++ b/charts/funnel/files/worker-pv-posix.yaml
@@ -1,0 +1,36 @@
+# Shared empty directory between all executor pods
+#
+# Caveats/Limitations:
+# - Requires all Worker + Executor pods for a given task are scheduled on the same node (RWO)
+# - Currently exploring alternative approaches to support POSIX + RWX (e.g. EFS, NFS, AWS S3 Files, emptyDir)
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: funnel-posix-pv-{{`{{.TaskId}}`}}
+  labels:
+    app: funnel
+    taskId: {{`{{.TaskId}}`}}
+    namespace: {{`{{.Namespace}}`}}
+spec:
+  storageClassName: "" # Required for static provisioning
+  capacity:
+    storage: "10Gi"
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Delete
+  {{- if .Values.kubernetes.posixVolume.efsFileSystemId }}
+  csi:
+    driver: nfs.csi.aws.com
+    volumeHandle: {{`{{.TaskId}}`}}-{{ .Values.kubernetes.posixVolume.nfsFileSystemId }}
+    # volumeHandle format for EFS static provisioning:
+    # fs-id[:access-point-id][::subpath]
+    # Using a task-scoped subpath so each task gets its own directory on the EFS filesystem
+    volumeHandle: {{ .Values.kubernetes.posixVolume.nfsFileSystemId }}::{{`{{.TaskId}}`}}
+  {{- else }}
+  hostPath:
+    path: /tmp/funnel-posix/{{`{{.TaskId}}`}}
+    type: DirectoryOrCreate
+  {{- end }}
+  claimRef:
+    namespace: {{`{{.Namespace}}`}}
+    name: funnel-posix-pvc-{{`{{.TaskId}}`}}


### PR DESCRIPTION
# Overview 🌀

This PR releases Helm Chart `v0.1.99-rc.37` (`2026-05-27`) addressing the following issues:

- [#76 Script errors should not be reported as "SYSTEM_ERROR"](https://ohsucomputationalbio.slack.com/lists/T04MS9FKW/F079AU1KCUX?record_id=Rec0B20LYDW1W)

- Note: Releasing 2026-06-03 in Helm Chart v0.1.99-rc.28!
